### PR TITLE
twitterの429に対するエラーハンドリングを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,10 +5,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from Twitter::Error::NotFound, with: :not_found
   rescue_from Twitter::Error::Unauthorized, with: :unauthorized
-
-  def render_404
-    render template: 'errors/error_404', status: 404
-  end
+  rescue_from Twitter::Error::TooManyRequests, with: :too_many_requests
 
   def render_500(e)
     logger.error "error_500: #{e.message}"
@@ -16,13 +13,21 @@ class ApplicationController < ActionController::Base
     render template: 'errors/error_500', status: 500
   end
 
-  def unauthorized
-    flash[:danger] = "非公開アカウントだよ。公開アカウントを入力してね。"
-    redirect_back(fallback_location: root_path)
+  def render_404
+    render template: 'errors/error_404', status: 404
   end
 
   def not_found
     flash[:danger] = "有効なアカウントを入力してね。"
     redirect_back(fallback_location: root_path)
+  end
+
+  def unauthorized
+    flash[:danger] = "非公開アカウントだよ。公開アカウントを入力してね。"
+    redirect_back(fallback_location: root_path)
+  end
+
+  def too_many_requests
+    render template: 'errors/error_429', status: 429
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,3 +1,3 @@
 class TopController < ApplicationController
-  def index;end
+  def index; end
 end

--- a/app/javascript/stylesheets/shared/error_message.scss
+++ b/app/javascript/stylesheets/shared/error_message.scss
@@ -6,6 +6,7 @@
 .error .error_title {
   margin-top: 20vh;
   font-size: $sub_title_text;
+  margin-bottom: 1rem;
 }
 
 .error .error_discription {

--- a/app/views/errors/error_429.html.slim
+++ b/app/views/errors/error_429.html.slim
@@ -1,0 +1,14 @@
+- content_for(:title, '429エラー')
+
+.error
+  .error_title
+    | 429 Too Many Requests
+  .error_discription
+    | 大変申し訳ありません。<br/>
+    | 現在リクエストが集中しているため、サービスを利用することができません。<br/>
+    | お手数をおかけしますが、15分程度お時間を置いてから再度アクセスしてください。<br/>
+
+.return_link
+  = link_to root_path, data: {"turbolinks" => false} do
+    i class="fas fa-door-open"
+    | トップページに戻る


### PR DESCRIPTION
- [ ] twitterのエラー429に対するエラーハンドリング実装
- [ ] 429のエラーページを作成

429 => Twitter::Error::TooManyRequests
同じ429コードのTWEET_RATE_LIMIT_EXCEEDEDも補足

参考↓
https://www.rubydoc.info/gems/twitter/Twitter/Error#rate_limit-instance_method
https://developer.twitter.com/ja/docs/twitter-ads-api/response-codes