### PR TITLE
Aws::Comprehend::Errors::ValidationException Request size cannot be zero.のエラー解消

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -42,8 +42,8 @@ class ResultsController < ApplicationController
 
     # exclude_replies: true => 返信を除去, include_rts: false => retweetを除去
     @client.user_timeline(@user, exclude_replies: true, include_rts: false).take(5).each do |tw|
-      # ハッシュ、url、空欄、改行、ファイルを削除。.gsub(/https?:\/\/+t.co\/.*$/,"")
-      @tweets << tw.text.gsub(/#.*$/, "").gsub(/http.*\s/, "").gsub(/[ 　]+/,"").gsub(/\n/,"").gsub(/http.*\/\/t.co\/.*$/, "")
+      # ハッシュ、url、空欄、改行、ファイルを削除。gsub(/http.*\/\/t.co\/.*$/, "")
+      @tweets << tw.text.gsub(/#.*$/, "").gsub(/http.*\s/, "").gsub(/[ 　]+/,"").gsub(/\n/,"")
     end
 
     twitter_params = {


### PR DESCRIPTION
何回か発生しているエラーだが、毎回user_timelineの取得のところで、画像データを除くgsub部分で発生している様子。
正規表現を変えて動かしてみるとしばらくは動いているが、時間がたつとまた発生するので一度削除して運用してみる。

```
@client.user_timeline(@user, exclude_replies: true, include_rts: false).take(5).each do |tw|

  @tweets << tw.text.gsub(/#.*$/, "").gsub(/http.*\s/, "").gsub(/[ 　]+/,"").gsub(/\n/,"") #.gsub(/http.*\/\/t.co\/.*$/, "")
end
```